### PR TITLE
Update Chrome columns

### DIFF
--- a/_includes/compat-table.html
+++ b/_includes/compat-table.html
@@ -21,7 +21,7 @@
                 <a href="https://www.w3.org/TR/webxr/">Spec</a><br />
             </td>
             <td>Supported, will make use of WebVR if available and WebXR is not.</td>
-            <td>Chrome 79 December 10th 2019</td>
+            <td>Supported, Chrome 79+</td>
             <td>Android standalones and PC in (Q1 2020)</td>
             <td>Demo on Hololens2 (Q4 2019 or Q1 2020)</td>
             <td>Magic Leap Helio 0.98</td>
@@ -50,7 +50,7 @@
             </td>
             <td></td>
             <td></td>
-            <td></td>
+            <td>Supported, Chrome 79+</td>
             <td></td>
             <td>Partially supported on Magic Leap Helio 0.98</td>
             <td></td>


### PR DESCRIPTION
Chrome supports Gamepad Module as of v79, and since that's been the stable version for a while now I think there's no need to include a date.