### PR TITLE
Fixed Compat Table

### DIFF
--- a/_includes/compat-table.html
+++ b/_includes/compat-table.html
@@ -49,8 +49,8 @@
                 <a href="https://www.w3.org/TR/webxr-gamepads-module-1/">Spec</a><br />
             </td>
             <td>Supported</td>
-            <td></td>
             <td>Supported, Chrome 79+</td>
+            <td></td>
             <td></td>
             <td>Partially supported on Magic Leap Helio 0.98</td>
             <td></td>


### PR DESCRIPTION
The chrome item is one column off for the gamepads module support, this fixes that.