### PR TITLE
Removed Firefox Reality from compat-table.html

### DIFF
--- a/_includes/compat-table.html
+++ b/_includes/compat-table.html
@@ -6,7 +6,6 @@
             <td>Standardisation</td>
             <td><a href="https://github.com/immersive-web/webxr-polyfill">Polyfill</a></td>
             <td>Chrome</td>
-            <td>Firefox Reality</td>
             <td>Servo</td>
             <td>WebXR Viewer</td>
             <td>Magic Leap Helio</td>
@@ -23,7 +22,6 @@
             </td>
             <td>Supported, will make use of WebVR if available and WebXR is not.</td>
             <td>Chrome 79</td>
-            <td>Android standalones. PC coming soon</td>
             <td>Hololens2</td>
             <td>iOS</td>
             <td>Magic Leap Helio 0.98</td>
@@ -38,7 +36,6 @@
             </td>
             <td>Not Supported</td>
             <td>Chrome for Android, 81</td>
-            <td></td>
             <td>Hololens2</td>
             <td>iOS</td>
             <td>Magic Leap Helio 0.98</td>
@@ -55,7 +52,6 @@
             <td>Chrome 79</td>
             <td></td>
             <td></td>
-            <td></td>
             <td>Partially supported on Magic Leap Helio 0.98</td>
             <td>Samsung Internet 12.0</td>
             <td>7.1, December 2019</td>
@@ -68,7 +64,6 @@
             </td>
             <td></td>
             <td>Chrome for Android, 81</td>
-            <td><!--Firefox Reality--></td>
             <td><!--Servo--></td>
             <td><!--WebXR Viewer--></td>
             <td><!--Magic Leap Helio--></td>
@@ -83,7 +78,6 @@
             </td>
             <td></td>
             <td>Chrome for Android, 83</td>
-            <td><!--Firefox Reality--></td>
             <td><!--Servo--></td>
             <td><!--WebXR Viewer--></td>
             <td><!--Magic Leap Helio--></td>
@@ -98,7 +92,6 @@
             </td>
             <td></td>
             <td><!--Chrome--></td>
-            <td><!--Firefox Reality--></td>
             <td><!--Servo--></td>
             <td><!--WebXR Viewer--></td>
             <td><!--Magic Leap Helio--></td>
@@ -112,7 +105,6 @@
             </td>
             <td></td>
             <td><!--Chrome--></td>
-            <td><!--Firefox Reality--></td>
             <td><!--Servo-->Prototyped for Hololens2 behind a pref</td>
             <td><!--WebXR Viewer--></td>
             <td><!--Magic Leap Helio--></td>
@@ -127,7 +119,6 @@
             </td>
             <td></td>
             <td><!--Chrome-->Chrome for Android, 85</td>
-            <td><!--Firefox Reality--></td>
             <td><!--Servo--></td>
             <td><!--WebXR Viewer--></td>
             <td><!--Magic Leap Helio--></td>
@@ -141,7 +132,6 @@
             </td>
             <td></td>
             <td><!--Chrome--><a href="https://developers.chrome.com/origintrials/#/view_trial/1934296039955628033">Origin Trial</a> in Chrome for Android, 87-88 </td>
-            <td><!--Firefox Reality--></td>
             <td><!--Servo--></td>
             <td><!--WebXR Viewer--></td>
             <td><!--Magic Leap Helio--></td>
@@ -155,7 +145,6 @@
             </td>
             <td></td>
             <td><!--Chrome--><a href="https://developers.chrome.com/origintrials/#/view_trial/4456311831283105793">Origin Trial</a> in Chrome for Android, 88-89 </td>
-            <td><!--Firefox Reality--></td>
             <td><!--Servo--></td>
             <td><!--WebXR Viewer--></td>
             <td><!--Magic Leap Helio--></td>
@@ -167,7 +156,6 @@
             <td></td>
             <td></td>
             <td><a href="chrome-support.html">Hardware Support Details</a></td>
-            <td></td>
             <td><a href="https://blog.mozvr.com/firefox-reality-hololens/">Final release announcement</a></td>
             <td><a href="https://blog.mozvr.com/webxr-viewer-2-0-released/">2.0 announcement</a></td>
             <td></td>
@@ -180,7 +168,6 @@
                 <a href="explainerurl">Explainer</a><br />
                 <a href="specurl">Spec</a><br />
             </td>
-            <td></td>
             <td></td>
             <td></td>
             <td></td>


### PR DESCRIPTION
With Firefox Reality shutting down, maybe it can be removed from the list making it a bit easier to read?