### PR TITLE
added for hand input and lighting estimation

### DIFF
--- a/_includes/compat-table.html
+++ b/_includes/compat-table.html
@@ -109,6 +109,7 @@
             <td>Hand input</td>
             <td>
                 <a href="https://github.com/immersive-web/webxr-hands-input/blob/master/explainer.md">Explainer</a><br />
+                <a href="https://www.w3.org/TR/webxr-hand-input-1/">Spec</a><br />
             </td>
             <td></td>
             <td><!--Chrome--></td>
@@ -152,6 +153,7 @@
             <td>Light Estimation</td>
             <td>
                 <a href="https://github.com/immersive-web/lighting-estimation/blob/main/lighting-estimation-explainer.md">Explainer</a><br />
+                <a href="https://immersive-web.github.io/lighting-estimation/">Spec</a><br />
             </td>
             <td></td>
             <td><!--Chrome--><a href="https://developers.chrome.com/origintrials/#/view_trial/4456311831283105793">Origin Trial</a> in Chrome for Android, 88-89 </td>


### PR DESCRIPTION
Q?
- should links to spec be unified to /TR/ for ones which have?
- should list both WD and ED?