### PR TITLE
Update compat-table.html

### DIFF
--- a/_includes/compat-table.html
+++ b/_includes/compat-table.html
@@ -68,7 +68,7 @@
             </td>
             <td><!--Polyfill--></td>
             <td>Chrome for Android, 81</td>
-            <td><!--WebXR Viewer--></td>
+            <td>IOS</td>
             <td><!--Magic Leap Helio--></td>
             <td>Samsung Internet 12.1</td>
             <td><!--Oculus Browser--></td>
@@ -83,7 +83,7 @@
             </td>
             <td><!--Polyfill--></td>
             <td>Chrome for Android, 83</td>
-            <td><!--WebXR Viewer--></td>
+            <td>IOS</td>
             <td><!--Magic Leap Helio--></td>
             <td>Samsung Internet 14.2</td>
             <td><!--Oculus Browser--></td>


### PR DESCRIPTION
webxr viewer on ios supports both "hittest" as well as "dom overlays since at least 24. 11. 2020 (tested on https://artificialmuseum.com)