### PR TITLE
use style instead of comment for template

### DIFF
--- a/_includes/compat-table.html
+++ b/_includes/compat-table.html
@@ -186,7 +186,7 @@
             <td><a href="https://docs.microsoft.com/en-us/windows/mixed-reality/whats-new/new-microsoft-edge"/>The new Microsoft Edge for Windows Mixed Reality</td>
             <td><a href="https://www.igalia.com/2022/02/03/Introducing-Wolvic.html" />Introducing Wolvic</td>
         </tr>
-        <!-- <tr>
+        <tr style="display: none">
             <td>Name</td>
             <td>
                 <a href="explainerurl">Explainer</a><br />
@@ -199,5 +199,5 @@
             <td><!--Samsung Internet--></td>
             <td><!--Oculus Browser--></td>
             <td><!--Microsoft Edge--></td>
-        </tr> -->
+        </tr>
 </table>


### PR DESCRIPTION
current site has garbaged `--> ` above the compat table. Using style instead of failed nested comment may be the easiest fix.