### PR TITLE
Update compat-table.html

### DIFF
--- a/_includes/compat-table.html
+++ b/_includes/compat-table.html
@@ -133,7 +133,7 @@
             <td><!--Magic Leap Helio--></td>
             <td><!--Samsung Internet--></td>
             <td><!--Meta Quest Browser-->15.1,<br/>April 2021</td>
-            <td>Edge 93. Hololens 2 only</td>
+            <td>Edge 93-109 on Hololens 2</td>
             <td><!--Wolvic--></td>
             <td><!--Pico Browser--></td>
             <td><!--Immersive Web Emulator--></td>


### PR DESCRIPTION
add Info that hand input is not working since Edge 110, February 2023

since the update to Edge 110, the hand property of the XRInputSource from the XRInputSourceEvent is `null`, instead of the required `XRHand`, needed to display hands. On canary from a week ago, it was still like this, haven't tested since. see https://developer.mozilla.org/en-US/docs/Web/API/XRInputSource/hand

People on the WebXR discord are confirming this: https://discord.com/channels/758943204715659264/805647111625375764
