### PR TITLE
Fix some formatting on the table

### DIFF
--- a/_includes/compat-table.html
+++ b/_includes/compat-table.html
@@ -32,7 +32,8 @@
             <td>Samsung Internet 12.0</td>
             <td>7.0, December 2019</td>
             <td>Edge 87 on Windows Desktop <br>Edge 91 on Hololens 2</td>
-            <td>0.9.3, February 2022</td>             <td><!--Pico Browser--></td>
+            <td>0.9.3, February 2022</td>
+            <td><!--Pico Browser-->Supported</td>
             <td><!--Immersive Web Emulator-->Supported</td>
             <td><!--Polyfill-->Supported, will make use of WebVR if available and WebXR is not.</td>
         </tr>
@@ -50,7 +51,8 @@
             <td>Samsung Internet 12.1</td>
             <td>24.0, October 2022</td>
             <td>Edge 91. Hololens 2 only</td>
-            <td><!--Wolvic--></td>             <td><!--Pico Browser--></td>
+            <td><!--Wolvic--></td>
+            <td><!--Pico Browser--></td>
             <td><!--Immersive Web Emulator--></td>
             <td><!--Polyfill--></td>
         </tr>
@@ -68,7 +70,8 @@
             <td>Samsung Internet 12.0</td>
             <td>7.1, December 2019</td>
             <td>Edge 87 on Windows Desktop <br>Edge 91 on Hololens 2</td>
-            <td>0.9.3, February 2022</td>             <td><!--Pico Browser--></td>
+            <td>0.9.3, February 2022</td>
+            <td>Supported</td>
             <td>Supported</td>
             <td>Supported</td>
         </tr>


### PR DESCRIPTION
I noticed when looking at the compat table that the formatting was off and Pico was missing its "Supported" indicators, so this fixes that