### PR TITLE
Fix article tabs: image horizontal size

### DIFF
--- a/main.css
+++ b/main.css
@@ -162,6 +162,10 @@ nav[role="tablist"] > a:target {
     pointer-events: painted;
 }
 
+.tabs img {
+    max-width: 100%;
+}
+
 *:focus {
     outline: 3px solid #24aef4;
 }


### PR DESCRIPTION
Adding some CSS to clamp img max-width


https://github.com/immersive-web/immersiveweb.dev/assets/5083203/09ce0bae-2d57-4355-be78-72a39092599f

