### PR TITLE
Add link to MQB Dev Docs in Compat Table

### DIFF
--- a/_includes/compat-table.html
+++ b/_includes/compat-table.html
@@ -216,7 +216,7 @@
             <td><a href="https://blog.mozvr.com/webxr-viewer-2-0-released/">2.0 announcement</a></td>
             <td><!--Magic Leap Helio--></td>
             <td><!--Samsung Internet--></td>
-            <td><!--Meta Quest Browser--></td>
+            <td><a href="https://developer.oculus.com/documentation/web/browser-intro/">Meta Quest Browser Dev Docs</a>></td>
             <td><a href="https://docs.microsoft.com/en-us/windows/mixed-reality/whats-new/new-microsoft-edge"/>The new Microsoft Edge for Windows Mixed Reality</td>
             <td><a href="https://www.igalia.com/2022/02/03/Introducing-Wolvic.html" />Introducing Wolvic</td>
             <td><!--Pico Browser--></td>


### PR DESCRIPTION
Added a link to MQB Developer Docs in the "Additional Details" row of the Compat Table.